### PR TITLE
ci(benchmarks): run arm64 legs on hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,10 +1,4 @@
 self-hosted-runner:
   labels:
-    - runner-small
     - runner-medium
-    - runner-medium-arm64
-    - runner-large
-    - runner-large-arm64
-    - runner-large-spot
-    - runner-medium-arm64-spot
     - runner-gpu-l4

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -78,7 +78,7 @@ jobs:
       github.repository == 'xberg-io/sceptre' && github.actor != 'dependabot[bot]' &&
       github.event_name == 'workflow_dispatch' &&
       (inputs.legs == 'all' || inputs.legs == 'criterion')
-    runs-on: runner-large-arm64
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
@@ -199,7 +199,7 @@ jobs:
       github.repository == 'xberg-io/sceptre' && github.actor != 'dependabot[bot]' &&
       github.event_name == 'workflow_dispatch' &&
       (inputs.legs == 'all' || inputs.legs == 'backend-matrix')
-    runs-on: runner-large-arm64
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     env:
       HF_HOME: ${{ github.workspace }}/.hf


### PR DESCRIPTION
Criterion and backend-matrix-linux-cpu move to `ubuntu-24.04-arm` now that the self-hosted arm64 pools are retired; their numbers need re-baselining.

`easyocr-benchmark` deliberately stays on `runner-medium` — ADR 0035 records that runner label as provenance and the `--assert` floors were measured there, so moving it to a shared hosted runner would invalidate both. That pool is being kept for exactly this reason.